### PR TITLE
bugfix: warn user if an account isn't connected to a phone number

### DIFF
--- a/fuo_netease/login_controller.py
+++ b/fuo_netease/login_controller.py
@@ -43,6 +43,8 @@ class LoginController(object):
         if data is None:
             return {'code': 408, 'message': '网络状况不好'}
         elif data['code'] == 200:
+            if data.get("profile") is None:
+                return {'code': 302, 'message': '请先在网页版绑定手机'}
             return {'code': 200, 'message': '登陆成功',
                     'data': data, 'username': username}
         elif data['code'] == 415:


### PR DESCRIPTION
如果用户尝试登录一个没有绑定手机号的账户（可能是从邮箱账户转过来的旧用户），登录时会返回正常的 status code，但是用户的 profile field 会完全丢失造成 feeluown crash ([#FeelUOwn/389](https://github.com/feeluown/FeelUOwn/issues/389) 和 [#FeelUOwn/210](https://github.com/feeluown/FeelUOwn/issues/210)，如果强行登录多项基础功能（日推、我的专辑）都无法正常使用（网易会直接返回 302 错误）。
为了防止给用户带来困扰，这个 PR 在登录的时候就检查是否存在 profile field，如果不存在，就提醒用户先在网页版绑定手机。