### PR TITLE
Fix a warning under Python 3.7+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,13 @@ setup(
         },
     url='https://github.com/feeluown/feeluown-netease',
     keywords=['feeluown', 'plugin', 'netease'],
-    classifiers=(
+    classifiers=[
         'Development Status :: 3 - Alpha',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3 :: Only',
-        ),
+    ],
     install_requires=[
         'feeluown>=3.3.9',
         'beautifulsoup4',


### PR DESCRIPTION
`Warning: 'classifiers' should be a list, got type 'tuple'`

Related issue: https://bugs.python.org/issue19610